### PR TITLE
Add package variable and a PHP Class template

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ using UnityEngine;
         {AUTHORNAME}
         {AUTHOREMAIL}
         {COMPANY}
+        {PACKAGE}
         {DATE} {TIME}
 ------------------------------------------------------------------------------*/
 
@@ -88,6 +89,7 @@ cpp-class-header.tpl
         {AUTHORNAME}
         {AUTHOREMAIL}
         {COMPANY}
+        {PACKAGE}
         {DATE} {TIME}
 ------------------------------------------------------------------------------*/
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -203,6 +203,7 @@ module.exports = Main = {
         content = content.replace(/{AUTHORNAME}/g, atom.config.get('spl-file-templates.authorName'));
         content = content.replace(/{AUTHOREMAIL}/g, atom.config.get('spl-file-templates.authorEmail'));
         content = content.replace(/{COMPANY}/g, atom.config.get('spl-file-templates.company'));
+        content = content.replace(/{PACKAGE}/g, atom.config.get('spl-file-templates.package'));
 
         fs.writeFileSync(destinationFile, content, 'utf8');
     },

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,6 +30,10 @@ module.exports = Main = {
         company: {
             type: 'string',
             default: '<Change this in the package settings.>'
+        },
+        package: {
+            type: 'string',
+            default: '<Change this in the package settings.>'
         }
     },
 

--- a/templates/php-class.json
+++ b/templates/php-class.json
@@ -1,0 +1,10 @@
+{
+    "templateName": "PHP Class Template",
+    "files": [
+        {
+            "template": "php-class.tpl",
+            "extension": "php",
+            "prefix": null
+        }
+    ]
+}

--- a/templates/php-class.tpl
+++ b/templates/php-class.tpl
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of {PACKAGE} package.
+ *
+ * (c) {AUTHORNAME} <{AUTHOREMAIL}>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace {COMPANY}\{PACKAGE};
+
+class {NAME}
+{
+    public function __construct()
+    {
+    }
+}


### PR DESCRIPTION
Greetings,
I am really happy to have found that incredible package for Atom. I was tired to write <?php ... each time that I needed to create a PHP Class, now is much more easy. Thanks!

But I was missing something. The package declaration, at namespace. So I added that varible in your atom's package, been honest I think it isn't the best solution because you must change settings each time you are working in a new package. But its better than nothing.

I have more sugestions to improve that tool, other thing I miss is a shortcut to create files with templates. For my understand the better solution should be override Ctrl+a and apply one template or other deppending the extencion file. I could be amazing.

Let me know 
